### PR TITLE
fix(zpam): preserve stats on reconnect before stale 999-ping timeout

### DIFF
--- a/source/maps/mp/gametypes/_player_stat.gsc
+++ b/source/maps/mp/gametypes/_player_stat.gsc
@@ -98,6 +98,38 @@ findData(name, entityId, hwid)
   return -1;
 }
 
+findReconnectData(name, entityId, hwid)
+{
+  dataId = findData(name, entityId, hwid);
+  if (dataId >= 0 && game["playerstats"][dataId]["isConnected"] == false)
+    return dataId;
+
+  // Reclaim stale 999 client row immediately when the same player reconnects
+  // before the old connection times out on cracked servers.
+  if (isDefined(hwid) && hwid != "")
+  {
+    for (i = 0; i < game["playerstats"].size; i++)
+    {
+      data = game["playerstats"][i];
+      if (data["deleted"]) continue;
+
+      if (data["hwid"] == hwid && data["name"] == name)
+        return i;
+    }
+  }
+
+  for (i = 0; i < game["playerstats"].size; i++)
+  {
+    data = game["playerstats"][i];
+    if (data["deleted"]) continue;
+
+    if (data["name"] == name && data["isConnected"] == false)
+      return i;
+  }
+
+  return -1;
+}
+
 handleRename()
 {
   if (isDefined(self.pers["lastName"]))
@@ -202,13 +234,16 @@ onConnected()
 
 	id = self getEntityNumber();
 
-	dataId = findData(self.name, id, self getHWID());
-	if (dataId >= 0 && game["playerstats"][dataId]["isConnected"] == false) // note: isConnected is reseted every map_restart
+	dataId = findReconnectData(self.name, id, self getHWID());
+	if (dataId >= 0) // note: isConnected is reseted every map_restart
 	{
 		game["playerstats"][dataId]["player"] = self;
+		game["playerstats"][dataId]["entityId"] = id;
+		game["playerstats"][dataId]["hwid"] = self getHWID();
 		game["playerstats"][dataId]["isConnected"] = true;
 		game["playerstats"][dataId]["team"] = self.sessionteam;
 		game["playerstats"][dataId]["lastTime"] = getTime();
+		game["playerstats"][dataId]["name"] = self.name;
 
 		self thread restoreScore(game["playerstats"][dataId]["kills"], game["playerstats"][dataId]["deaths"]);
 	}


### PR DESCRIPTION
## Summary

Fixes a reconnect bug where a player could disconnect, remain on the server briefly with 999 ping, reconnect before timeout, and receive a fresh stats row starting from 0.

## Problem

On cracked-server flow, the stale connection can remain alive long enough for the same player to reconnect.
The reconnect path did not reclaim the original player stats entry if the old row was still marked connected, so a new entry was created instead.
That caused the previous score to be lost and the new 0-score entry to override the old one in-game and in FPSChallenge.

## Fix

- add a reconnect lookup that prefers reclaiming the existing player stats row
- match reconnects by HWID and name when the stale client is still present
- update the reclaimed row with the new entity id and current player reference
- restore score/deaths from the original stats entry instead of creating a fresh one

## Testing

Tested flow to verify:
1. join server and gain score
2. break connection so old client remains with 999 ping
3. reconnect before automatic timeout
4. confirm previous score is preserved and not replaced by a new 0-score entry
